### PR TITLE
[SASS-11413] add nino into session

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file("."))
   .settings(
     name := appName,
     version := appVersion,
-    scalaVersion := "2.13.12",
+    scalaVersion := "2.13.16",
     //implicitConversions & postfixOps are Gatling recommended -language settings
     scalacOptions ++= Seq("-feature", "-language:implicitConversions", "-language:postfixOps"),
     // Enabling sbt-auto-build plugin provides DefaultBuildSettings with default `testOptions` from `sbt-settings` plugin.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,6 @@ import sbt._
 
 object Dependencies {
 
-  private val gatlingVersion = "3.4.2"
-
   val test: Seq[ModuleID] = Seq(
     "com.typesafe" % "config" % "1.4.2" % Test,
     "uk.gov.hmrc" %% "performance-test-runner" % "6.1.0" % Test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
 
-addSbtPlugin("io.gatling" % "gatling-sbt" % "3.2.1")
+addSbtPlugin("io.gatling" % "gatling-sbt" % "4.9.2")

--- a/run_smoke_tests_tailor_return.sh
+++ b/run_smoke_tests_tailor_return.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sbt -Dperftest.runSmokeTest=true -DrunLocal=true -Dperftest.labels=tailorReturnFlows gatling:test

--- a/src/test/scala/uk/gov/hmrc/perftests/itsass/requests/RequestsHelper.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/itsass/requests/RequestsHelper.scala
@@ -58,7 +58,6 @@ object RequestsHelper extends ServicesConfiguration with TaxYearHelper {
   val propertyUrl: String => String = (taxYear: String) => propertyBaseUrl + s"/update-and-submit-income-tax-return/property/$taxYear"
   val miniJourneyUrl: String => String = (taxYear: String) => personalIncomeBaseUrl + s"/update-and-submit-income-tax-return/personal-income/$taxYear"
   val selfEmploymentUrl: String => String = (taxYear: String) => selfEmploymentBaseUrl + s"/update-and-submit-income-tax-return/self-employment/$taxYear"
-  val stubDataUrl: String => String = (taxYear: String) => tailorReturnBaseUrl + s"/update-and-submit-income-tax-return/tailored-return/test-only/$taxYear/add-data"
 
   val csrfPattern: String = """<input type="hidden" name="csrfToken" value="([^"]+)"/>"""
   val untaxedAccountPattern: String = s"""/update-and-submit-income-tax-return/personal-income/$taxYear/interest/add-untaxed-uk-interest-account/([^"]+)"""

--- a/src/test/scala/uk/gov/hmrc/perftests/itsass/requests/TailorReturnRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/itsass/requests/TailorReturnRequests.scala
@@ -464,8 +464,7 @@ object TailorReturnRequests extends ServicesConfiguration {
     .formParam("value[]", "fromUkBanks")
     .check(status.is(303))
 
-  def postStubData(taxYear: String): HttpRequestBuilder = http("Post stub data")
-    .get(s"${stubDataUrl(taxYear)}")
-//    .check(saveCsrfToken())
-    .check(status.is(303))
+  def getTaskListPage(taxYear: String): HttpRequestBuilder = http("Get Tailored Return Task List Page")
+    .get(s"${tailorReturnUrl(taxYear)}/overview")
+    .check(status.is(200))
 }

--- a/src/test/scala/uk/gov/hmrc/perftests/itsass/simSteps/TailorReturnSimSteps.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/itsass/simSteps/TailorReturnSimSteps.scala
@@ -16,18 +16,26 @@
 
 package uk.gov.hmrc.perftests.itsass.simSteps
 
-import uk.gov.hmrc.performance.simulation.{JourneyPart, PerformanceTestRunner}
-import uk.gov.hmrc.perftests.itsass.requests.TailorReturnRequests._
+import io.gatling.core.action.builder.PauseBuilder
+import io.gatling.core.session.ExpressionSuccessWrapper
+import uk.gov.hmrc.performance.simulation._
 import uk.gov.hmrc.perftests.itsass.requests.AuthLoginRequests.{getLoginPage, postAgentLoginPage, postIndividualLoginPage}
-import uk.gov.hmrc.perftests.itsass.requests.DividendsRequests.{getCheckCloseCompanyLoanAmountPage, getCheckRedeemableSharesAmountPage, getCheckStockDividendsAmountPage, getCheckUKDividendsAmountPage, getCloseCompanyLoanAmountPage, getCloseCompanyLoanSectionCompletedPage, getOtherDividendsAmountPage, getRedeemableSharesAmountPage, getRedeemableSharesSectionCompletedPage, getStockDividendSectionCompletedPage, getStockDividendsAmountPage, getUKDividendsAmountPage, postCheckCloseCompanyLoanAmountPage, postCheckRedeemableSharesAmountPage, postCheckStockDividendsAmountPage, postCheckUKDividendsAmountPage, postCloseCompanyLoanAmountPage, postCloseCompanyLoanSectionCompletedPage, postOtherDividendsAmountPage, postRedeemableSharesAmountPage, postRedeemableSharesSectionCompletedPage, postStockDividendSectionCompletedPage, postStockDividendsAmountPage, postUKDividendsAmountPage}
+import uk.gov.hmrc.perftests.itsass.requests.DividendsRequests._
 import uk.gov.hmrc.perftests.itsass.requests.IncomeTaxSubmissionRequests.{getInsertAdditionalParametersEndPoint, getStartPage, getYourIncomeTaxReturnPage}
 import uk.gov.hmrc.perftests.itsass.requests.RequestsHelper.taxYear
+import uk.gov.hmrc.perftests.itsass.requests.TailorReturnRequests._
+
+import scala.concurrent.duration.DurationInt
 
 trait TailorReturnSimSteps extends PerformanceTestRunner {
 
-  def IndividualTaskList(id: String, description: String): JourneyPart = setup(id, description) withRequests(
+  def pause(millis: Int) = new PauseBuilder(millis.millis.expressionSuccess, None)
+
+  def IndividualTaskList(id: String, description: String): JourneyPart = setup(id, description).withRequests(
     getLoginPage,
     postIndividualLoginPage("AA123459A", "1234567890", taxYear),
+    //TODO: The below is a temporary fix; a code change is required to retrieve NINO from Auth for Individuals
+    getInsertAdditionalParametersEndPoint("AA123459A", "1234567890", taxYear),
     getStartPage(taxYear),
     getTailorReturnStartPage(taxYear),
     getTailorReturnAddSectionsPage(taxYear),
@@ -95,7 +103,7 @@ trait TailorReturnSimSteps extends PerformanceTestRunner {
     postPaymentsPensionsPage(taxYear),
     getChangePaymentsPensionsPage(taxYear),
     postChangePaymentsPensionsPage(taxYear),
-    getYourIncomeTaxReturnPage(taxYear)
+    getTaskListPage(taxYear)
   )
 
   def AgentTaskList(id: String, description: String): JourneyPart = setup(id, description) withRequests(
@@ -177,12 +185,14 @@ trait TailorReturnSimSteps extends PerformanceTestRunner {
     postPaymentsPensionsPage(taxYear),
     getChangePaymentsPensionsPage(taxYear),
     postChangePaymentsPensionsPage(taxYear),
-    getYourIncomeTaxReturnPage(taxYear)
+    getTaskListPage(taxYear)
   )
 
   def IndividualDividends(id: String, description: String): JourneyPart = setup(id, description) withRequests(
     getLoginPage,
     postIndividualLoginPage("AA123459A", "1234567890", taxYear),
+    //TODO: The below is a temporary fix; a code change is required to retrieve NINO from Auth for Individuals
+    getInsertAdditionalParametersEndPoint("AA123459A", "1234567890", taxYear),
     getStartPage(taxYear),
     getTailorReturnStartPage(taxYear),
     getTailorReturnAddSectionsPage(taxYear),
@@ -224,7 +234,7 @@ trait TailorReturnSimSteps extends PerformanceTestRunner {
     postAllDividendsSharesLoansPage(taxYear),
     getPaymentsPensionsPage(taxYear),
     postPaymentsPensionsPage(taxYear),
-    getYourIncomeTaxReturnPage(taxYear),
+    getTaskListPage(taxYear),
     getUKDividendsAmountPage(taxYear),
     postUKDividendsAmountPage(taxYear),
     getCheckUKDividendsAmountPage(taxYear),


### PR DESCRIPTION
Adds the NINO into the session (this is partly a temporary fix, as this should only be required for Agents. For Individuals, a code change is needed to retrieve the NINO from Auth).

It also corrects to check the TaskList in the Tailored Returns flow at the end, instead of the main Task List.

Includes gatling dependency bump to work with Java21
